### PR TITLE
Enable users to see other's profile

### DIFF
--- a/study-connect/app/components/ClassMembers.tsx
+++ b/study-connect/app/components/ClassMembers.tsx
@@ -11,7 +11,7 @@ interface ClassMembersProps {
 export default function ClassMembers({ selectedClass }: ClassMembersProps) {
   const [selectedClassId, setSelectedClassId] = useState<string>(selectedClass.courseId);
   const [selectedClassQuarter, setSelectedClassQuarter] = useState<string>(selectedClass.courseQuarter);
-  const [courseMembers, setCourseMembers] = useState<{ name: string; profilePic: string }[]>([]);
+  const [courseMembers, setCourseMembers] = useState<{ name: string; profilePic: string; userId: string }[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -32,6 +32,7 @@ export default function ClassMembers({ selectedClass }: ClassMembersProps) {
                 memberData.push({
                   name: userData.name,
                   profilePic: userData.profilePic,
+                  userId: member
                 });
               }
             }
@@ -72,7 +73,7 @@ export default function ClassMembers({ selectedClass }: ClassMembersProps) {
               </Avatar>
               <div className="flex-1 space-y-1">
                 <div className="flex items-center">
-                  <span className="font-semibold text-gray-600">{member.name}</span>
+                  <a href={`/profile/${member.userId}`} className="font-semibold text-gray-600 hover:underline">{member.name}</a>
                 </div>
               </div>
             </div>

--- a/study-connect/app/components/ProfileContent.tsx
+++ b/study-connect/app/components/ProfileContent.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { User, Class } from "../utils/interfaces";
+import { useRouter } from "next/navigation";
 import { fetchClassByCourseId } from "../utils/functions";
 import { useRef, useState } from "react";
 import { auth } from '../../lib/firebase';
@@ -7,6 +8,11 @@ import { getFirestore, doc, setDoc } from 'firebase/firestore';
 
 export default function ProfileContent({ user, setUser }: { user: User, setUser: (user: User) => void }) {
   const db = getFirestore();
+
+  const router = useRouter();
+  const authUser = auth.currentUser;
+  const isOwnProfile = authUser?.uid === user.userId; // True if viewing own profile
+  // console.log("user.uid: ", user.userID);
 
   const [isPopupOpen, setIsPopupOpen] = useState(false);
   const [isProfilePicPopupOpen, setIsProfilePicPopupOpen] = useState(false);
@@ -33,6 +39,14 @@ export default function ProfileContent({ user, setUser }: { user: User, setUser:
       console.log("courseData: ", courseData);
       setSelectedCourse(courseData);
       setIsPopupOpen(true);
+    }
+  };
+
+  const handleUserClick = (uid: string) => {
+    if (uid !== authUser?.uid) {
+      router.push(`/profile/${uid}`);
+    } else {
+      router.push(`/profile`);
     }
   };
 
@@ -151,9 +165,12 @@ export default function ProfileContent({ user, setUser }: { user: User, setUser:
             <div className="w-2/3 flex flex-col justify-center px-6">
               <div className="flex justify-between w-full">
                 <h2 className="text-gray-600 text-xl font-bold">{user.name}</h2>
-                <Link href="/profile/edit" className="text-xs text-amber-500 bg-blue-950 border border-black-500 rounded px-4 py-2">
-                  Edit Profile
-                </Link>
+                {/* Show EDIT BUTTON only if the current user matches the profile page */}
+                {isOwnProfile && (
+                  <Link href="/profile/edit" className="text-xs text-amber-500 bg-blue-950 border border-black-500 rounded px-4 py-2">
+                    Edit Profile
+                  </Link>
+                )}
               </div>
               <p className="text-gray-600">Email: {user.email}</p>
               <p className="text-gray-600">Grade: {user.grade}</p>

--- a/study-connect/app/components/ProfileContent.tsx
+++ b/study-connect/app/components/ProfileContent.tsx
@@ -12,7 +12,7 @@ export default function ProfileContent({ user, setUser }: { user: User, setUser:
   const router = useRouter();
   const authUser = auth.currentUser;
   const isOwnProfile = authUser?.uid === user.userId; // True if viewing own profile
-  // console.log("user.uid: ", user.userID);
+  // console.log("user.uid: ", user.userId);
 
   const [isPopupOpen, setIsPopupOpen] = useState(false);
   const [isProfilePicPopupOpen, setIsProfilePicPopupOpen] = useState(false);
@@ -144,23 +144,26 @@ export default function ProfileContent({ user, setUser }: { user: User, setUser:
           <div className="flex w-full p-4 justify-between">
             {/* Profile Picture */}
             <div
-              className="flex justify-center relative group cursor-pointer"
-              onClick={() => handleProfilePicClick()}
+              className={`flex justify-center relative group ${isOwnProfile ? 'cursor-pointer' : ''}`}
+              onClick={isOwnProfile ? () => handleProfilePicClick() : undefined}
             >
               <img
                 src={user.profilePic}
                 alt="Profile"
-                className="w-32 h-32 rounded-full object-cover transition-all duration-300 ease-in-out group-hover:opacity-50"
+                className="w-32 h-32 rounded-full object-cover transition-all duration-300 ease-in-out 
+                  ${isOwnProfile ? 'group-hover:opacity-50' : ''}"
               />
-              {/* Pencil Icon centered on hover */}
-              <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-300 ease-in-out">
-                <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="#555555" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <path d="M12 20h9"></path>
-                  <path d="M16 4l4 4L7 16H3v-4L16 4z"></path>
-                </svg>
-              </div>
+              {/* Pencil Icon centered on hover, only if it's the user's own profile */}
+              {isOwnProfile && (
+                <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-300 ease-in-out">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="#555555" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M12 20h9"></path>
+                    <path d="M16 4l4 4L7 16H3v-4L16 4z"></path>
+                  </svg>
+                </div>
+              )}
             </div>
-  
+
             {/* User Info */}
             <div className="w-2/3 flex flex-col justify-center px-6">
               <div className="flex justify-between w-full">
@@ -179,6 +182,7 @@ export default function ProfileContent({ user, setUser }: { user: User, setUser:
             </div>
           </div>
         </div>
+
 
         <div className="bg-white shadow-md rounded-2xl p-6 mb-6">
           <div className="break-words">

--- a/study-connect/app/components/WebChat.tsx
+++ b/study-connect/app/components/WebChat.tsx
@@ -10,6 +10,7 @@ type Message = {
   id: string
   user: {
     name: string
+    userId: string
     avatar: string
   }
   content: string
@@ -21,7 +22,7 @@ type Message = {
 const initialMessages: Message[] = [
   {
     id: "1",
-    user: { name: "Alice", avatar: "/placeholder.svg?height=40&width=40" },
+    user: { name: "Alice", userId: "testId1", avatar: "/placeholder.svg?height=40&width=40" },
     content: "Hey everyone! How's it going?",
     timestamp: "2:30 PM",
     courseId: "class1",
@@ -29,7 +30,7 @@ const initialMessages: Message[] = [
   },
   {
     id: "2",
-    user: { name: "Bob", avatar: "/placeholder.svg?height=40&width=40" },
+    user: { name: "Bob", userId: "testId2", avatar: "/placeholder.svg?height=40&width=40" },
     content: "Hi Alice! All good here. How about you?",
     timestamp: "2:32 PM",
     courseId: "class1",
@@ -37,7 +38,7 @@ const initialMessages: Message[] = [
   },
   {
     id: "3",
-    user: { name: "Charlie", avatar: "/placeholder.svg?height=40&width=40" },
+    user: { name: "Charlie", userId: "testId3", avatar: "/placeholder.svg?height=40&width=40" },
     content: "Hello folks! Just joined the chat.",
     timestamp: "2:35 PM",
     courseId: "class1",
@@ -91,7 +92,7 @@ function formatQuarter(quarterCode: string): string {
 export default function WebChat({ selectedClass }: WebChatProps) {
   const [messages, setMessages] = useState<Message[]>([])
   const [newMessage, setNewMessage] = useState("")
-  const [userData, setUserData] = useState<{ name: string; profilePic: string } | null>(null)
+  const [userData, setUserData] = useState<{ name: string; profilePic: string; userId: string } | null>(null)
   const messagesEndRef = useRef<HTMLDivElement>(null)
 
   // Create a unique chat room ID using courseId and quarter
@@ -112,6 +113,7 @@ export default function WebChat({ selectedClass }: WebChatProps) {
             const data = userDoc.data();
             setUserData({
               name: data.name || 'Anonymous',
+              userId: user.uid, 
               profilePic: data.profilePic || 'https://upload.wikimedia.org/wikipedia/commons/a/ac/Default_pfp.jpg'
             });
           }
@@ -156,6 +158,7 @@ export default function WebChat({ selectedClass }: WebChatProps) {
       await addDoc(chatRoomRef, {
         user: {
           name: userData.name,
+          userId: userData.userId,
           avatar: userData.profilePic
         },
         content: newMessage.trim(),
@@ -183,7 +186,7 @@ export default function WebChat({ selectedClass }: WebChatProps) {
             </Avatar>
             <div className="flex-1 space-y-1">
               <div className="flex items-center">
-                <span className="font-semibold text-gray-600">{message.user.name}</span>
+                <a href={`/profile/${message.user.userId}`} className="font-semibold text-gray-600 hover:underline">{message.user.name}</a> 
                 <span className="text-xs text-gray-600 text-muted-foreground ml-2">
                   {formatTimestamp(message.timestamp)}
                 </span>

--- a/study-connect/app/posts/[postId]/page.tsx
+++ b/study-connect/app/posts/[postId]/page.tsx
@@ -187,7 +187,8 @@ export default function PostPage({ params }: { params: Promise<{ postId: string 
             <h1 className="text-3xl sm:text-4xl font-bold text-gray-900 mb-4">{post.title}</h1>
             
             <div className="flex items-center space-x-2 text-sm text-gray-600 mb-8">
-              <span className="font-medium text-gray-900">{post.authorName}</span>
+              {/* Change author name to a clickable link to author profile */}
+              <a href={`/profile/${post.authorId}`} className="font-medium text-gray-900 hover:underline">{post.authorName}</a> 
               <span>•</span>
               <time dateTime={new Date(post.createdAt._seconds * 1000).toISOString()}>
                 {formatDate(post.createdAt)}

--- a/study-connect/app/profile/[uid]/page.tsx
+++ b/study-connect/app/profile/[uid]/page.tsx
@@ -1,0 +1,63 @@
+'use client'
+import { useState, useEffect, Suspense } from "react";
+import { useRouter, useParams } from "next/navigation";
+import dynamic from "next/dynamic";
+import { db } from '../../../lib/firebase';
+import { doc, getDoc } from 'firebase/firestore';
+import { User } from '../../utils/interfaces';
+
+const ProfileContent = dynamic(() => import('../../components/ProfileContent'), {
+    ssr: false,
+    loading: () => (
+        <div className="h-screen flex items-center justify-center">
+            <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-500"></div>
+        </div>
+    )
+});
+
+export default function UserProfile() {
+    const [user, setUser] = useState<User | null>(null);
+    const { uid } = useParams(); 
+
+    useEffect(() => {
+        if (!uid) return;
+        const fetchUserProfile = async () => {
+            try {
+                const userDoc = await getDoc(doc(db, 'users', uid as string));
+                if (userDoc.exists()) {
+                    const userData = userDoc.data();
+                    // console.log("uid in profile[uid]", uid);
+                    setUser({
+                        userId: uid as string|| '',
+                        name: userData.name || '',
+                        email: userData.email || '',
+                        grade: userData.grade || '',
+                        major: userData.major || '',
+                        minor: userData.minor || '',
+                        joinedClasses: userData.joinedClasses || [],
+                        profilePic: userData.profilePic || 'https://upload.wikimedia.org/wikipedia/commons/a/ac/Default_pfp.jpg',
+                        aboutMe: userData.aboutMe || '',
+                    });
+                }
+            } catch (error) {
+                console.error("Error fetching user profile: ", error);
+            }
+        };
+
+        fetchUserProfile();
+    }, [uid]);
+
+    if (!user) {
+        return (
+            <div className="h-screen flex items-center justify-center">
+            <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-500"></div>
+            </div>
+        );
+        }
+
+        return (
+        <Suspense fallback={<div className="h-screen flex justify-center items-center">Loading...</div>}>
+            <ProfileContent user={user} setUser={setUser} />
+        </Suspense>
+    );
+}

--- a/study-connect/app/profile/page.tsx
+++ b/study-connect/app/profile/page.tsx
@@ -33,7 +33,7 @@ export default function Profile() {
                 console.log("userData: ", userData);
                 console.log("user.uid in profile page: ", user.uid); 
                 setUser({
-                    userID: user.uid || '',
+                    userId: user.uid || '',
                     name: userData.name || '',
                     email: user.email || '',
                     grade: userData.grade || '',

--- a/study-connect/app/profile/page.tsx
+++ b/study-connect/app/profile/page.tsx
@@ -31,7 +31,9 @@ export default function Profile() {
             if (userDoc.exists()) {
                 const userData = userDoc.data();
                 console.log("userData: ", userData);
+                console.log("user.uid in profile page: ", user.uid); 
                 setUser({
+                    userID: user.uid || '',
                     name: userData.name || '',
                     email: user.email || '',
                     grade: userData.grade || '',

--- a/study-connect/app/utils/interfaces.tsx
+++ b/study-connect/app/utils/interfaces.tsx
@@ -1,4 +1,5 @@
 export interface User {
+    userId: string;
     name: string;
     email: string;
     grade: string;


### PR DESCRIPTION
Changes:

1. Add a new page that directs to the user's profile page by their userId
2. Modified the author name in post detail page and class forum to a href directing to the author's profile page
3. Modified ProfileContent to make sure user's can only edit their own profile. 
4. Also updated the names in ClassMember component to make them clickable. 

Acceptance tests:

1. Go to home page and select a class in the sidebar.
2. Click on the "members" button and click on any member's name, then you will be directed to that person's profile page
3. Read a post and click on the author's name, then you will be directed to the author's profile page
4. In class chat, send a new message, and click your name, you will be directed to your own profile page with an "edit profile" button displayed. All the historical chats did not record the messager's uid so you cannot go to their profile. 
5. When you are on other user's profile page, you should neither see the "Edit profile" button nor pencil icon on profile pic. 

<img width="1671" alt="image" src="https://github.com/user-attachments/assets/00aec970-a782-48cb-ba28-a78e4f001f5c" />
<img width="1588" alt="image" src="https://github.com/user-attachments/assets/73f5b1b2-b654-4590-a561-37e238979285" />


Closes #70 