### PR TITLE
Added Friends Page + Fixed Navbar to top of screen

### DIFF
--- a/study-connect/app/components/ClassForum.tsx
+++ b/study-connect/app/components/ClassForum.tsx
@@ -171,7 +171,7 @@ export default function ClassForum({ selectedClassId, selectedClassQuarter, onCl
     <div className="p-6 bg-white rounded-lg shadow">
       <div className="flex justify-between items-center mb-6">
         <h2 className="text-2xl font-bold text-black">{selectedClassId} - {selectedClassQuarter && QUARTERMAP[selectedClassQuarter[selectedClassQuarter.length - 1] as keyof typeof QUARTERMAP]} {selectedClassQuarter && selectedClassQuarter.substring(0, 4)} Forums</h2>
-        <div className="flex justify-between items-center space-x-4 ml-auto">
+        <div className="flex justify-between items-center space-x-4">
           <button
             className="px-2 py-1 bg-blue-500 text-white rounded-md hover:bg-blue-600"
             onClick={handleInfoClick}

--- a/study-connect/app/components/ClassesSidebar.tsx
+++ b/study-connect/app/components/ClassesSidebar.tsx
@@ -75,7 +75,7 @@ export default function ClassesSidebar({ setSelectedClassId, setSelectedClassQua
   }, {} as Record<string, JoinedClass[]>);
 
   return (
-    <div className="w-64 bg-white shadow-md sticky top-0 h-1">
+    <div className="w-64 bg-white shadow-md h-1">
       <div className="p-4 border-b">
         <h2 className="text-lg font-semibold text-gray-800">My Classes</h2>
       </div>

--- a/study-connect/app/components/WebChat.tsx
+++ b/study-connect/app/components/WebChat.tsx
@@ -18,33 +18,6 @@ type Message = {
   courseId: string
   courseQuarter: string
 }
-//placeholder messages just for the sake of showing the UI, these will be deleted
-const initialMessages: Message[] = [
-  {
-    id: "1",
-    user: { name: "Alice", userId: "testId1", avatar: "/placeholder.svg?height=40&width=40" },
-    content: "Hey everyone! How's it going?",
-    timestamp: "2:30 PM",
-    courseId: "class1",
-    courseQuarter: "Q1"
-  },
-  {
-    id: "2",
-    user: { name: "Bob", userId: "testId2", avatar: "/placeholder.svg?height=40&width=40" },
-    content: "Hi Alice! All good here. How about you?",
-    timestamp: "2:32 PM",
-    courseId: "class1",
-    courseQuarter: "Q1"
-  },
-  {
-    id: "3",
-    user: { name: "Charlie", userId: "testId3", avatar: "/placeholder.svg?height=40&width=40" },
-    content: "Hello folks! Just joined the chat.",
-    timestamp: "2:35 PM",
-    courseId: "class1",
-    courseQuarter: "Q1"
-  },
-]
 
 interface WebChatProps {
   selectedClass: JoinedClass;  // Change to accept full class info

--- a/study-connect/app/components/WebChat.tsx
+++ b/study-connect/app/components/WebChat.tsx
@@ -154,7 +154,7 @@ export default function WebChat({ selectedClass }: WebChatProps) {
       <div className="flex-grow p-4 overflow-y-auto">
         {messages.map((message) => (
           <div key={message.id} className="flex items-start space-x-4 mb-4">
-            <Avatar src={message.user.avatar} alt={message.user.name}>
+            <Avatar sx={{position:'static'}} src={message.user.avatar} alt={message.user.name}>
               {message.user.name.charAt(0)}
             </Avatar>
             <div className="flex-1 space-y-1">

--- a/study-connect/app/components/navbar.tsx
+++ b/study-connect/app/components/navbar.tsx
@@ -178,7 +178,7 @@ export const Navbar = () => {
     const pendingRequests = getPendingFriendRequests();
 
     return (
-        <nav className="bg-white text-black p-4 sm:p-6">
+        <nav className="sticky top-0 bg-white text-black p-4 sm:p-6">
             <div className="container mx-auto flex justify-between items-center">
                 <Link href="/" className="text-3xl font-bold">
                     study-connect
@@ -191,6 +191,9 @@ export const Navbar = () => {
                             </Link>
                             <Link href="/profile" className="hover:text-blue-300 text-2xl"> 
                                 profile
+                            </Link>
+                            <Link href="/friends" className="hover:text-blue-300 text-2xl"> 
+                                friends
                             </Link>
                             
                             {/* Notification Bell */}

--- a/study-connect/app/courses/page.tsx
+++ b/study-connect/app/courses/page.tsx
@@ -526,7 +526,7 @@ export default function ExploreCourses() {
       </div>
 
       {/* right panel */}
-      <div className="flex flex-col flex-1 p-8 space-y-8 bg-white rounded-lg shadow-md m-4 min-h-screen overflow-y-auto sticky top-0 h-1">
+      <div className="flex flex-col flex-1 p-8 space-y-8 bg-white rounded-lg shadow-md m-4 min-h-screen overflow-y-auto h-1">
         <div className="text-center">
           <h1 className="text-3xl font-bold text-gray-900">Class Info</h1>
           <p className="mt-2 text-gray-600">Basic class information</p>

--- a/study-connect/app/friends/page.tsx
+++ b/study-connect/app/friends/page.tsx
@@ -112,7 +112,7 @@ import Link from 'next/link';
           }
   
           return (
-            <div className="flex-1 p-8">
+            <div className="flex-1 p-8 bg-gray-50">
                 <div className="flex h-screen">
                 <div className="w-2/5 p-4 border-r overflow-y-auto h-full">
                   {friendsList.map(friend => (

--- a/study-connect/app/friends/page.tsx
+++ b/study-connect/app/friends/page.tsx
@@ -1,0 +1,174 @@
+'use client'
+
+import { useState, useEffect, Suspense } from "react";
+import { useRouter } from "next/navigation";
+import dynamic from "next/dynamic";
+import { auth, db } from '../../lib/firebase';
+import { doc, getDoc } from 'firebase/firestore';
+import { User } from '../utils/interfaces';
+import Image from 'next/image';
+import Link from 'next/link';
+/*
+const ProfileContent = dynamic(() => import('../components/ProfileContent'), {
+    ssr: false,
+    loading: () => (
+        <div className="h-screen flex items-center justify-center">
+          <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-500"></div>
+        </div>
+      )
+  });
+  */
+  
+  export default function Friends() {
+      const [user, setUser] = useState<User | null>(null);
+      const [friendsList, setFriendsList] = useState<User[]>([]);
+      const [loadingFriends, setLoadingFriends] = useState(false);
+      const router = useRouter();
+  
+      useEffect(() => {
+        const unsubscribe = auth.onAuthStateChanged(async (user) => {
+          if (!user) {
+              router.push('/');
+              return;
+          }
+  
+          try {
+              const userDoc = await getDoc(doc(db, 'users', user.uid));
+              if (userDoc.exists()) {
+                  const userData = userDoc.data();
+                  console.log("userData: ", userData);
+                  console.log("user.uid in profile page: ", user.uid); 
+                  setUser({
+                      userId: user.uid || '',
+                      name: userData.name || '',
+                      email: user.email || '',
+                      grade: userData.grade || '',
+                      major: userData.major || '',
+                      minor: userData.minor || '',
+                      joinedClasses: userData.joinedClasses || [],
+                      profilePic: userData.profilePic || 'https://upload.wikimedia.org/wikipedia/commons/a/ac/Default_pfp.jpg',
+                      aboutMe: userData.aboutMe || '',
+                      friends: userData.friends || [],
+                      friendRequests: userData.friendRequests || []
+                  });
+              }
+          } catch (error) {
+              console.error("Error getting user document: ", error);
+          }
+        });
+  
+        return () => unsubscribe();
+      }, [router]);
+  
+      // Fetch friends data when user is loaded
+      useEffect(() => {
+          if (!user || !user.friends || user.friends.length === 0) {
+              setFriendsList([]);
+              return;
+          }
+          
+          const fetchFriends = async () => {
+              setLoadingFriends(true);
+              try {
+                  const friendsData: User[] = [];
+                  
+                  // Fetch each friend's data
+                  for (const friendId of user.friends) {
+                      const friendDoc = await getDoc(doc(db, 'users', friendId));
+                      if (friendDoc.exists()) {
+                          const data = friendDoc.data();
+                          friendsData.push({
+                              userId: friendId,
+                              name: data.name || '',
+                              email: data.email || '',
+                              grade: data.grade || '',
+                              major: data.major || '',
+                              minor: data.minor || '',
+                              joinedClasses: data.joinedClasses || [],
+                              profilePic: data.profilePic || 'https://upload.wikimedia.org/wikipedia/commons/a/ac/Default_pfp.jpg',
+                              aboutMe: data.aboutMe || '',
+                              friends: data.friends || [],
+                              friendRequests: data.friendRequests || [],
+                          });
+                      }
+                  }
+                  
+                  setFriendsList(friendsData);
+              } catch (error) {
+                  console.error("Error fetching friends: ", error);
+              } finally {
+                  setLoadingFriends(false);
+              }
+          };
+          
+          fetchFriends();
+      }, [user]);
+  
+      const renderFriendsList = () => {
+          if (loadingFriends) {
+              return (
+                  <div className="flex justify-center py-8">
+                      <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-500"></div>
+                  </div>
+              );
+          }
+  
+          if (friendsList.length === 0) {
+              return (
+                  <div className="text-center py-8 text-gray-500">
+                      You don't have any friends yet. Add some friends to connect!
+                  </div>
+              );
+          }
+  
+          return (
+            <div className="flex-1 p-8">
+                <div className="flex h-screen">
+                <div className="w-2/5 p-4 border-r overflow-y-auto h-full">
+                  {friendsList.map(friend => (
+                      <Link 
+                          href={`/profile/${friend.userId}`} 
+                          key={friend.userId}
+                          className="flex items-center p-4 bg-white rounded-lg shadow-sm hover:shadow-md transition-shadow"
+                      >
+                          <Image 
+                              src={friend.profilePic} 
+                              alt={friend.name}
+                              width={50}
+                              height={50}
+                              className="rounded-full mr-4"
+                          />
+                          <div>
+                              <h3 className="font-medium text-gray-900">{friend.name}</h3>
+                              <p className="text-sm text-gray-500">{friend.major}</p>
+                          </div>
+                      </Link>
+                  ))}
+                </div>
+                <div className="w-3/5 p-4 border-r overflow-y-auto h-full tect-gray-600">
+                  WebChat Goes Here, Placeholder Message
+                </div>
+                </div>
+              </div>
+          );
+      };
+  
+      if (!user) {
+        return (
+          <div className="h-screen flex items-center justify-center">
+            <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-500"></div>
+          </div>
+        );
+      }
+  
+      return (
+        <Suspense fallback={<div className="h-screen flex justify-center items-center">Loading...</div>}>
+          
+          {/* Friends List Section */}
+          <div className="mt-8 px-8">
+              <h2 className="text-2xl font-bold mb-4">Friends ({user.friends.length})</h2>
+              {renderFriendsList()}
+          </div>
+        </Suspense>
+      );
+  }

--- a/study-connect/app/friends/page.tsx
+++ b/study-connect/app/friends/page.tsx
@@ -8,16 +8,6 @@ import { doc, getDoc } from 'firebase/firestore';
 import { User } from '../utils/interfaces';
 import Image from 'next/image';
 import Link from 'next/link';
-/*
-const ProfileContent = dynamic(() => import('../components/ProfileContent'), {
-    ssr: false,
-    loading: () => (
-        <div className="h-screen flex items-center justify-center">
-          <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-500"></div>
-        </div>
-      )
-  });
-  */
   
   export default function Friends() {
       const [user, setUser] = useState<User | null>(null);
@@ -145,7 +135,7 @@ const ProfileContent = dynamic(() => import('../components/ProfileContent'), {
                       </Link>
                   ))}
                 </div>
-                <div className="w-3/5 p-4 border-r overflow-y-auto h-full tect-gray-600">
+                <div className="w-3/5 p-4 border-r overflow-y-auto h-full text-gray-600">
                   WebChat Goes Here, Placeholder Message
                 </div>
                 </div>

--- a/study-connect/app/profile/page.tsx
+++ b/study-connect/app/profile/page.tsx
@@ -19,8 +19,6 @@ const ProfileContent = dynamic(() => import('../components/ProfileContent'), {
 
 export default function Profile() {
     const [user, setUser] = useState<User | null>(null);
-    const [friendsList, setFriendsList] = useState<User[]>([]);
-    const [loadingFriends, setLoadingFriends] = useState(false);
     const router = useRouter();
 
     useEffect(() => {
@@ -58,92 +56,6 @@ export default function Profile() {
       return () => unsubscribe();
     }, [router]);
 
-    // Fetch friends data when user is loaded
-    useEffect(() => {
-        if (!user || !user.friends || user.friends.length === 0) {
-            setFriendsList([]);
-            return;
-        }
-        
-        const fetchFriends = async () => {
-            setLoadingFriends(true);
-            try {
-                const friendsData: User[] = [];
-                
-                // Fetch each friend's data
-                for (const friendId of user.friends) {
-                    const friendDoc = await getDoc(doc(db, 'users', friendId));
-                    if (friendDoc.exists()) {
-                        const data = friendDoc.data();
-                        friendsData.push({
-                            userId: friendId,
-                            name: data.name || '',
-                            email: data.email || '',
-                            grade: data.grade || '',
-                            major: data.major || '',
-                            minor: data.minor || '',
-                            joinedClasses: data.joinedClasses || [],
-                            profilePic: data.profilePic || 'https://upload.wikimedia.org/wikipedia/commons/a/ac/Default_pfp.jpg',
-                            aboutMe: data.aboutMe || '',
-                            friends: data.friends || [],
-                            friendRequests: data.friendRequests || [],
-                        });
-                    }
-                }
-                
-                setFriendsList(friendsData);
-            } catch (error) {
-                console.error("Error fetching friends: ", error);
-            } finally {
-                setLoadingFriends(false);
-            }
-        };
-        
-        fetchFriends();
-    }, [user]);
-
-    const renderFriendsList = () => {
-        if (loadingFriends) {
-            return (
-                <div className="flex justify-center py-8">
-                    <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-500"></div>
-                </div>
-            );
-        }
-
-        if (friendsList.length === 0) {
-            return (
-                <div className="text-center py-8 text-gray-500">
-                    You don't have any friends yet. Add some friends to connect!
-                </div>
-            );
-        }
-
-        return (
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                {friendsList.map(friend => (
-                    <Link 
-                        href={`/profile/${friend.userId}`} 
-                        key={friend.userId}
-                        className="flex items-center p-4 bg-white rounded-lg shadow-sm hover:shadow-md transition-shadow"
-                    >
-                        <Image 
-                            src={friend.profilePic} 
-                            alt={friend.name}
-                            width={50}
-                            height={50}
-                            className="rounded-full mr-4"
-                        />
-                        <div>
-                            <h3 className="font-medium text-gray-900">{friend.name}</h3>
-                            <p className="text-sm text-gray-500">{friend.major}</p>
-                        </div>
-                    </Link>
-                ))}
-            </div>
-        );
-    };
-
     if (!user) {
       return (
         <div className="h-screen flex items-center justify-center">
@@ -155,12 +67,7 @@ export default function Profile() {
     return (
       <Suspense fallback={<div className="h-screen flex justify-center items-center">Loading...</div>}>
         <ProfileContent user={user} setUser={setUser} />
-        
-        {/* Friends List Section - Only shown on user's own profile */}
-        <div className="mt-8 px-8">
-            <h2 className="text-2xl font-bold mb-4">Friends ({user.friends.length})</h2>
-            {renderFriendsList()}
-        </div>
+
       </Suspense>
     );
 }


### PR DESCRIPTION
This PR moves the friends content from the profile page to a new friends page available from the navbar. It also adds a section for where the private webchats will go. 

Additionally, I've made it so the navigation bar stays on top of the screen even when you scroll down.

Testing Criteria:
[ ] Friend page renders and all friends are clickable and takes you to their profiles.
[ ] There is an area with placeholder text for the webchat.
[ ] Try to scroll on any page, the navbar should stick to the top of your screen.
[ ] Check that course chatroom doesn't clip into the navbar

Known Bugs: Profile picture clips through navbar when scrolling up

Closes #75 